### PR TITLE
Converted to black code style

### DIFF
--- a/nonstandardcode.py
+++ b/nonstandardcode.py
@@ -6,14 +6,19 @@ import tarfile
 import numpy as np
 import pandas as pd
 from scipy.stats import randint
+
 # from six import moves
 from six.moves import urllib
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LinearRegression
 from sklearn.metrics import mean_absolute_error, mean_squared_error
-from sklearn.model_selection import (GridSearchCV, RandomizedSearchCV,
-                                     StratifiedShuffleSplit, train_test_split)
+from sklearn.model_selection import (
+    GridSearchCV,
+    RandomizedSearchCV,
+    StratifiedShuffleSplit,
+    train_test_split,
+)
 from sklearn.tree import DecisionTreeRegressor
 
 DOWNLOAD_ROOT = "https://raw.githubusercontent.com/ageron/handson-ml/master/"
@@ -137,7 +142,6 @@ tree_rmse = np.sqrt(tree_mse)
 tree_rmse
 
 
-
 param_distribs = {
     "n_estimators": randint(low=1, high=200),
     "max_features": randint(low=1, high=8),
@@ -212,4 +216,3 @@ X_test_prepared = X_test_prepared.join(pd.get_dummies(X_test_cat, drop_first=Tru
 final_predictions = final_model.predict(X_test_prepared)
 final_mse = mean_squared_error(y_test, final_predictions)
 final_rmse = np.sqrt(final_mse)
-


### PR DESCRIPTION
Used isort, black to reformat the code and flake8 as linting tool.


![image](https://user-images.githubusercontent.com/109579169/181756656-742c4332-55eb-4b8c-bf5e-253dfe118acd.png)
